### PR TITLE
migrate language state to global LanguageContext across all yp&fa sceens

### DIFF
--- a/client/src/screens/FertilizerAdvisor/FertilizerAdvisorFarmerLandingScreen.tsx
+++ b/client/src/screens/FertilizerAdvisor/FertilizerAdvisorFarmerLandingScreen.tsx
@@ -15,6 +15,7 @@ import { useNavigation } from "@react-navigation/native";
 import { ArrowLeft, Sparkles, MessageCircle, AlertCircle } from "lucide-react-native";
 import { LinearGradient } from "expo-linear-gradient";
 import { useApp } from "../../context/AppContext";
+import { useLanguage } from "../../context/LanguageContext";
 
 const { width } = Dimensions.get("window");
 
@@ -42,7 +43,8 @@ const content = {
 export default function FertilizerAdvisorLandingScreen() {
     const navigation = useNavigation<any>();
     const { user } = useApp();
-    const [language, setLanguage] = useState<Language>("en");
+    const { language: lang } = useLanguage();
+    const language: Language = lang === "sinhala" ? "si" : "en";
     const [activeSlide, setActiveSlide] = useState(0);
     const scrollViewRef = useRef<ScrollView>(null);
 
@@ -141,14 +143,6 @@ export default function FertilizerAdvisorLandingScreen() {
                         <Text style={styles.headerTitle}>{t.title}</Text>
                         <Text style={styles.headerSubtitle}>{t.subtitle}</Text>
                     </View>
-                    <TouchableOpacity
-                        style={styles.langButton}
-                        onPress={() => setLanguage((prev) => (prev === "si" ? "en" : "si"))}
-                    >
-                        <Text style={styles.langText}>
-                            {language === "si" ? "EN" : "සිං"}
-                        </Text>
-                    </TouchableOpacity>
                 </View>
             </LinearGradient>
 

--- a/client/src/screens/FertilizerAdvisor/FertilizerAdvisorOfficerLandingScreen.tsx
+++ b/client/src/screens/FertilizerAdvisor/FertilizerAdvisorOfficerLandingScreen.tsx
@@ -11,6 +11,7 @@ import { useNavigation } from "@react-navigation/native";
 import { ArrowLeft, Users, MessageCircle, FileText, AlertCircle, Sparkles } from "lucide-react-native";
 import { LinearGradient } from "expo-linear-gradient";
 import { useApp } from "../../context/AppContext";
+import { useLanguage } from "../../context/LanguageContext";
 
 type Language = "si" | "en";
 
@@ -44,7 +45,8 @@ const content = {
 export default function FertilizerAdvisorOfficerLandingScreen() {
     const navigation = useNavigation<any>();
     const { user } = useApp();
-    const [language, setLanguage] = useState<Language>("en");
+    const { language: lang } = useLanguage();
+    const language: Language = lang === "sinhala" ? "si" : "en";
 
     // Check if user is an officer
     useEffect(() => {
@@ -139,14 +141,6 @@ export default function FertilizerAdvisorOfficerLandingScreen() {
                         <Text style={styles.headerTitle}>{t.title}</Text>
                         <Text style={styles.headerSubtitle}>{t.subtitle}</Text>
                     </View>
-                    <TouchableOpacity
-                        style={styles.langButton}
-                        onPress={() => setLanguage((prev) => (prev === "si" ? "en" : "si"))}
-                    >
-                        <Text style={styles.langText}>
-                            {language === "si" ? "EN" : "සිං"}
-                        </Text>
-                    </TouchableOpacity>
                 </View>
             </LinearGradient>
 

--- a/client/src/screens/FertilizerAdvisor/RuleBasedAdviceHelperOfficer/OfficerAdvisoryInputScreen.tsx
+++ b/client/src/screens/FertilizerAdvisor/RuleBasedAdviceHelperOfficer/OfficerAdvisoryInputScreen.tsx
@@ -21,6 +21,7 @@ import {
 } from "lucide-react-native";
 import { LinearGradient } from "expo-linear-gradient";
 import { useApp } from "../../../context/AppContext";
+import { useLanguage } from "../../../context/LanguageContext";
 
 const API_URL = process.env.EXPO_PUBLIC_API_BASE;
 
@@ -106,7 +107,8 @@ const symptomOptions = [
 export default function OfficerAdvisoryInputScreen() {
   const navigation = useNavigation<any>();
   const { user } = useApp();
-  const [language, setLanguage] = useState<Language>("en");
+  const { language: lang } = useLanguage();
+  const language: Language = lang === "sinhala" ? "si" : "en";
   const [loading, setLoading] = useState(false);
 
   const [growthStage, setGrowthStage] = useState("");
@@ -233,12 +235,6 @@ export default function OfficerAdvisoryInputScreen() {
             <Text style={styles.headerTitle}>{t.title}</Text>
             <Text style={styles.headerSubtitle}>{t.subtitle}</Text>
           </View>
-          <TouchableOpacity
-            style={styles.langButton}
-            onPress={() => setLanguage((prev) => (prev === "si" ? "en" : "si"))}
-          >
-            <Text style={styles.langText}>{language === "si" ? "EN" : "සිං"}</Text>
-          </TouchableOpacity>
         </View>
       </LinearGradient>
 

--- a/client/src/screens/FertilizerAdvisor/RuleBasedAdviceHelperOfficer/OfficerAdvisoryResultsScreen.tsx
+++ b/client/src/screens/FertilizerAdvisor/RuleBasedAdviceHelperOfficer/OfficerAdvisoryResultsScreen.tsx
@@ -6,6 +6,7 @@ import {
   StyleSheet,
   ScrollView,
 } from "react-native";
+import { useLanguage } from "../../../context/LanguageContext";
 import { useNavigation, useRoute } from "@react-navigation/native";
 import {
   ArrowLeft,
@@ -99,7 +100,8 @@ export default function OfficerAdvisoryResultsScreen() {
   const route = useRoute<any>();
   const { data, language: lang } = route.params;
 
-  const [language, setLanguage] = React.useState<Language>(lang || "en");
+  const { language: contextLang } = useLanguage();
+  const language: Language = contextLang === "sinhala" ? "si" : "en";
   const t = content[language];
 
   const getPriorityColor = (priority: string) => {
@@ -144,12 +146,6 @@ export default function OfficerAdvisoryResultsScreen() {
             <Text style={styles.headerTitle}>{t.title}</Text>
             <Text style={styles.headerSubtitle}>{t.subtitle}</Text>
           </View>
-          <TouchableOpacity
-            style={styles.langButton}
-            onPress={() => setLanguage((prev) => (prev === "si" ? "en" : "si"))}
-          >
-            <Text style={styles.langText}>{language === "si" ? "EN" : "සිං"}</Text>
-          </TouchableOpacity>
         </View>
       </LinearGradient>
 

--- a/client/src/screens/FertilizerAdvisor/RuleBasedAdvisoryFarmer/FertilizerAdvisoryFarmerInputScreen.tsx
+++ b/client/src/screens/FertilizerAdvisor/RuleBasedAdvisoryFarmer/FertilizerAdvisoryFarmerInputScreen.tsx
@@ -14,6 +14,7 @@ import { useNavigation } from "@react-navigation/native";
 import { ArrowLeft, MessageSquare, Send, AlertCircle } from "lucide-react-native";
 import { LinearGradient } from "expo-linear-gradient";
 import { useApp } from "../../../context/AppContext";
+import { useLanguage } from "../../../context/LanguageContext";
 
 const getApiUrl = () => {
     if (Platform.OS === "android") {
@@ -60,7 +61,8 @@ const content = {
 export default function RuleBasedAdvisoryInputScreen() {
     const navigation = useNavigation<any>();
     const { user } = useApp();
-    const [language, setLanguage] = useState<Language>("en");
+    const { language: lang } = useLanguage();
+    const language: Language = lang === "sinhala" ? "si" : "en";
     const [inputText, setInputText] = useState("");
     const [loading, setLoading] = useState(false);
     const [placeholderIndex, setPlaceholderIndex] = useState(0);
@@ -200,9 +202,6 @@ export default function RuleBasedAdvisoryInputScreen() {
                         <Text style={styles.headerTitle}>{t.title}</Text>
                         <Text style={styles.headerSubtitle}>{t.subtitle}</Text>
                     </View>
-                    <TouchableOpacity style={styles.langButton} onPress={() => setLanguage((p) => (p === "si" ? "en" : "si"))}>
-                        <Text style={styles.langText}>{language === "si" ? "EN" : "සිං"}</Text>
-                    </TouchableOpacity>
                 </View>
             </LinearGradient>
 

--- a/client/src/screens/FertilizerAdvisor/RuleBasedAdvisoryFarmer/FertilizerAdvisoryFarmerResultsScreen.tsx
+++ b/client/src/screens/FertilizerAdvisor/RuleBasedAdvisoryFarmer/FertilizerAdvisoryFarmerResultsScreen.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { View, Text, TouchableOpacity, StyleSheet, ScrollView } from "react-native";
+import { useLanguage } from "../../../context/LanguageContext";
 import { useNavigation, useRoute } from "@react-navigation/native";
 import {
   ArrowLeft,
@@ -81,7 +82,8 @@ export default function RuleBasedAdvisoryResultsScreen() {
     language: Language;
   };
 
-  const [language, setLanguage] = React.useState<Language>(lang || "en");
+  const { language: contextLang } = useLanguage();
+  const language: Language = contextLang === "sinhala" ? "si" : "en";
   const t = content[language];
 
   const canApplyToday = data.apply_today === true;
@@ -147,9 +149,6 @@ export default function RuleBasedAdvisoryResultsScreen() {
             <Text style={styles.headerTitle}>{t.title}</Text>
             <Text style={styles.headerSubtitle}>{t.subtitle}</Text>
           </View>
-          <TouchableOpacity style={styles.langButton} onPress={() => setLanguage((prev) => (prev === "si" ? "en" : "si"))}>
-            <Text style={styles.langText}>{language === "si" ? "EN" : "සිං"}</Text>
-          </TouchableOpacity>
         </View>
       </LinearGradient>
 

--- a/client/src/screens/YieldPrediction/YieldPredictionFarmerFormScreen.tsx
+++ b/client/src/screens/YieldPrediction/YieldPredictionFarmerFormScreen.tsx
@@ -19,6 +19,7 @@ import * as Location from "expo-location";
 import { fetchWeatherByCoordinates, getLocationCoordinates } from "../../services/weatherApi";
 import { predictYieldFarmer, FarmerPredictionRequest } from "../../services/yieldPredictionApi";
 import { useApp } from "../../context/AppContext";
+import { useLanguage } from "../../context/LanguageContext";
 
 type Language = "si" | "en";
 type NavProp = StackNavigationProp<
@@ -343,12 +344,12 @@ const RAINFALL_CONDITIONS_EN = [
 const YieldPredictionFormScreen = () => {
     const navigation = useNavigation<NavProp>();
     const route = useRoute();
-    const { role, language: initialLanguage } = route.params as {
+    const { role } = route.params as {
         role: "farmer" | "officer";
-        language: Language;
     };
 
-    const [language, setLanguage] = useState<Language>(initialLanguage);
+    const { language: lang } = useLanguage();
+    const language: Language = lang === "sinhala" ? "si" : "en";
     const [district, setDistrict] = useState("");
     const [location, setLocation] = useState("");
     const [plantingDate, setPlantingDate] = useState<Date | null>(null);
@@ -792,12 +793,6 @@ const YieldPredictionFormScreen = () => {
                     <Text style={styles.headerTitle}>{content[language].title}</Text>
                     <Text style={styles.headerSubtitle}>{content[language].subtitle}</Text>
                 </View>
-                <TouchableOpacity
-                    style={styles.langButton}
-                    onPress={() => setLanguage((prev) => (prev === "si" ? "en" : "si"))}
-                >
-                    <Text style={styles.langText}>{language === "si" ? "EN" : "සිං"}</Text>
-                </TouchableOpacity>
             </View>
 
             {/* Location & Weather Bar */}

--- a/client/src/screens/YieldPrediction/YieldPredictionFarmerResultsScreen.tsx
+++ b/client/src/screens/YieldPrediction/YieldPredictionFarmerResultsScreen.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useLanguage } from "../../context/LanguageContext";
 import {
   View,
   Text,
@@ -33,12 +34,12 @@ type NavProp = StackNavigationProp<
 const YieldPredictionResultsScreen = () => {
   const navigation = useNavigation<NavProp>();
   const route = useRoute();
-  const { data, language: initialLanguage } = route.params as {
+  const { data } = route.params as {
     data: any;
-    language: "si" | "en";
   };
 
-  const [language, setLanguage] = useState<"si" | "en">(initialLanguage);
+  const { language: lang } = useLanguage();
+  const language: "si" | "en" = lang === "sinhala" ? "si" : "en";
   const [fadeAnim] = useState(new Animated.Value(0));
 
   React.useEffect(() => {
@@ -137,14 +138,6 @@ const YieldPredictionResultsScreen = () => {
           <Text style={styles.headerTitle}>{content[language].title}</Text>
           <Text style={styles.headerSubtitle}>{content[language].subtitle}</Text>
         </View>
-        <TouchableOpacity
-          style={styles.langButton}
-          onPress={() => setLanguage((prev) => (prev === "si" ? "en" : "si"))}
-        >
-          <Text style={styles.langText}>
-            {language === "si" ? "EN" : "සිං"}
-          </Text>
-        </TouchableOpacity>
       </View>
 
       <ScrollView

--- a/client/src/screens/YieldPrediction/YieldPredictionLoadingScreen.tsx
+++ b/client/src/screens/YieldPrediction/YieldPredictionLoadingScreen.tsx
@@ -14,6 +14,7 @@ import type { StackNavigationProp } from "@react-navigation/stack";
 import type { YieldPredictionStackParamList } from "../../navigation/YieldPredictionStack";
 import { Leaf, Users, Package } from "lucide-react-native";
 import { useApp } from "../../context/AppContext";
+import { useLanguage } from "../../context/LanguageContext";
 
 const { width } = Dimensions.get("window");
 
@@ -24,7 +25,8 @@ type NavProp = StackNavigationProp<
 
 const YieldPredictionLoadingScreen = () => {
   const navigation = useNavigation<NavProp>();
-  const [language, setLanguage] = useState<"si" | "en">("si");
+  const { language: lang } = useLanguage();
+  const language: "si" | "en" = lang === "sinhala" ? "si" : "en";
   const [fadeAnim] = useState(new Animated.Value(0));
   const [scaleAnim] = useState(new Animated.Value(0.9));
   const { user } = useApp();
@@ -133,14 +135,6 @@ const YieldPredictionLoadingScreen = () => {
           <Text style={styles.headerTitle}>{content[language].title}</Text>
           <Text style={styles.headerSubtitle}>{content[language].subtitle}</Text>
         </View>
-        <TouchableOpacity
-          style={styles.langButton}
-          onPress={() => setLanguage((prev) => (prev === "si" ? "en" : "si"))}
-        >
-          <Text style={styles.langText}>
-            {language === "si" ? "EN" : "සිං"}
-          </Text>
-        </TouchableOpacity>
       </View>
 
       <ScrollView

--- a/client/src/screens/YieldPrediction/YieldPredictionOfficerFormScreen.tsx
+++ b/client/src/screens/YieldPrediction/YieldPredictionOfficerFormScreen.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useLanguage } from "../../context/LanguageContext";
 import {
   View,
   Text,
@@ -85,9 +86,12 @@ const NPK_STATUS = ["High", "Medium", "Low"];
 const YieldPredictionOfficerFormScreenNew = () => {
   const navigation = useNavigation<NavProp>();
   const route = useRoute();
-  const { language: initialLanguage } = route.params as { language: Language };
+  const { role } = route.params as {
+    role: "farmer" | "officer";
+  };
 
-  const [language, setLanguage] = useState<Language>(initialLanguage);
+  const { language: lang } = useLanguage();
+  const language: Language = lang === "sinhala" ? "si" : "en";
 
   // Location & Basic Info
   const [district, setDistrict] = useState("");
@@ -413,14 +417,6 @@ const YieldPredictionOfficerFormScreenNew = () => {
           <Text style={styles.headerTitle}>{content[language].title}</Text>
           <Text style={styles.headerSubtitle}>{content[language].subtitle}</Text>
         </View>
-        <TouchableOpacity
-          style={styles.langButton}
-          onPress={() => setLanguage((prev) => (prev === "si" ? "en" : "si"))}
-        >
-          <Text style={styles.langText}>
-            {language === "si" ? "EN" : "සිං"}
-          </Text>
-        </TouchableOpacity>
       </View>
 
       <ScrollView

--- a/client/src/screens/YieldPrediction/YieldPredictionOfficerResultsScreen.tsx
+++ b/client/src/screens/YieldPrediction/YieldPredictionOfficerResultsScreen.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { useLanguage } from "../../context/LanguageContext";
 import {
   View,
   Text,
@@ -33,12 +34,12 @@ type NavProp = StackNavigationProp<
 const YieldPredictionOfficerResultsScreenEnhanced = () => {
   const navigation = useNavigation<NavProp>();
   const route = useRoute();
-  const { data, language: initialLanguage } = route.params as {
+  const { data } = route.params as {
     data: any;
-    language: "si" | "en";
   };
 
-  const [language, setLanguage] = useState<"si" | "en">(initialLanguage);
+  const { language: lang } = useLanguage();
+  const language: "si" | "en" = lang === "sinhala" ? "si" : "en";
   const [fadeAnim] = useState(new Animated.Value(0));
 
   React.useEffect(() => {
@@ -208,14 +209,6 @@ const YieldPredictionOfficerResultsScreenEnhanced = () => {
           <Text style={styles.headerTitle}>{content[language].title}</Text>
           <Text style={styles.headerSubtitle}>{content[language].subtitle}</Text>
         </View>
-        <TouchableOpacity
-          style={styles.langButton}
-          onPress={() => setLanguage((prev) => (prev === "si" ? "en" : "si"))}
-        >
-          <Text style={styles.langText}>
-            {language === "si" ? "EN" : "සිං"}
-          </Text>
-        </TouchableOpacity>
       </View>
 
       <ScrollView


### PR DESCRIPTION
- remove local language state and toggle buttons from all screens
- integrate useLanguage hook from LanguageContext
- map context language ('sinhala'/'english') to screen language type ('si'/'en')
- remove language parameter from navigation route params